### PR TITLE
Convert bbox from a method to a property

### DIFF
--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -39,8 +39,12 @@ class BBoxMixin(object):
         self.attr['bbox']. The coordinates are assumed to be in the form
         of a comma-seperated string like so: "x0, y0, x1, y1"
 
-    Adds a bbox() method which returns a BBox object."""
+    Adds a bbox read-only bbox property.
+    
+    (See https://docs.python.org/3/library/functions.html#property for more about
+    properties, and a description of how to make this property read/write if desired)."""
 
+    @property
     def bbox(self):
         points = self.attr['bbox'].split(",")
         #box = BBox(points)

--- a/extract/test/test_bbox.py
+++ b/extract/test/test_bbox.py
@@ -10,7 +10,7 @@ class TestBboxClass(BBoxMixin):
 
 def test_bbox_mixin():
     t = TestBboxClass()
-    bb = t.bbox()
+    bb = t.bbox
     assert bb.x0 == 459.84
     assert bb.y0 == 753.697
     assert bb.x1 == 462.075


### PR DESCRIPTION
Here's an alternative, which is pretty much the same, except:

````python
bb = t.bbox()
````
becomes
````
bb = t.bbox
````

which possibly fits more naturally with the mental model of what the bbox is - that is, it's an attribute of t rather than a function of t.

This example creates a read-only property; see https://docs.python.org/3/library/functions.html#property for two different ways to make this a read/write property.

.... decorators. I should explain decorators.

https://docs.python.org/3/glossary.html#term-decorator

A function returning another function, usually applied as a function transformation using the @wrapper syntax. Common examples for decorators are classmethod() and staticmethod().

The decorator syntax is merely syntactic sugar, the following two function definitions are semantically equivalent:
````python
def f(...):
    ...
f = staticmethod(f)

@staticmethod
def f(...):
    ...
````

So you could do:

````python
def bbox(...):
    ....
property(bbox)
````
and it would be identical to
````python
@property
def bbox(...):
    ....
````

